### PR TITLE
Py3k-compatible print statements.

### DIFF
--- a/mkformat.py
+++ b/mkformat.py
@@ -10,4 +10,4 @@ with open(filename, 'rU') as fh:
     source = fh.read()
 
 statements = pymake.parser.parsestring(source, filename)
-print statements.to_source()
+print(statements.to_source())

--- a/mkparse.py
+++ b/mkparse.py
@@ -4,9 +4,9 @@ import sys
 import pymake.parser
 
 for f in sys.argv[1:]:
-    print "Parsing %s" % f
+    print("Parsing %s" % f)
     fd = open(f, 'rU')
     s = fd.read()
     fd.close()
     stmts = pymake.parser.parsestring(s, f)
-    print stmts
+    print(stmts)

--- a/pymake/command.py
+++ b/pymake/command.py
@@ -62,7 +62,7 @@ def parsemakeflags(env):
     return opts
 
 def _version(*args):
-    print """pymake: GNU-compatible make program
+    print("""pymake: GNU-compatible make program
 Copyright (C) 2009 The Mozilla Foundation <http://www.mozilla.org/>
 This is free software; see the source for copying conditions.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -71,7 +71,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE."""
+DEALINGS IN THE SOFTWARE.""")
 
 _log = logging.getLogger('pymake.execution')
 
@@ -95,7 +95,7 @@ class _MakeContext(object):
 
     def remakecb(self, remade, error=None):
         if error is not None:
-            print error
+            print(error)
             self.context.defer(self.cb, 2)
             return
 
@@ -125,14 +125,14 @@ class _MakeContext(object):
                 self.makefile.finishparsing()
                 self.makefile.remakemakefiles(self.remakecb)
             except util.MakeError, e:
-                print e
+                print(e)
                 self.context.defer(self.cb, 2)
 
             return
 
         if len(self.targets) == 0:
             if self.makefile.defaulttarget is None:
-                print "No target specified and no default target found."
+                print("No target specified and no default target found.")
                 self.context.defer(self.cb, 2)
                 return
 
@@ -154,7 +154,7 @@ class _MakeContext(object):
 
         if not len(self.realtargets):
             if self.options.printdir:
-                print "make.py[%i]: Leaving directory '%s'" % (self.makelevel, self.workdir)
+                print("make.py[%i]: Leaving directory '%s'" % (self.makelevel, self.workdir))
             sys.stdout.flush()
 
             self.context.defer(self.cb, 0)
@@ -255,14 +255,14 @@ def main(args, env, cwd, cb):
         context = process.getcontext(options.jobcount)
 
         if options.printdir:
-            print "make.py[%i]: Entering directory '%s'" % (makelevel, workdir)
+            print("make.py[%i]: Entering directory '%s'" % (makelevel, workdir))
             sys.stdout.flush()
 
         if len(options.makefiles) == 0:
             if os.path.exists(util.normaljoin(workdir, 'Makefile')):
                 options.makefiles.append('Makefile')
             else:
-                print "No makefile found"
+                print("No makefile found")
                 cb(2)
                 return
 
@@ -270,9 +270,9 @@ def main(args, env, cwd, cb):
 
         _MakeContext(makeflags, makelevel, workdir, context, env, targets, options, ostmts, overrides, cb)
     except (util.MakeError), e:
-        print e
+        print(e)
         if options.printdir:
-            print "make.py[%i]: Leaving directory '%s'" % (makelevel, workdir)
+            print("make.py[%i]: Leaving directory '%s'" % (makelevel, workdir))
         sys.stdout.flush()
         cb(2)
         return

--- a/pymake/data.py
+++ b/pymake/data.py
@@ -865,7 +865,7 @@ class RemakeRuleContext(object):
         assert error in (True, False)
 
         if error:
-            print "<%s>: Found error" % self.target.target
+            print("<%s>: Found error" % self.target.target)
             self.error = True
         if didanything:
             self.didanything = True
@@ -951,7 +951,7 @@ class RemakeRuleContext(object):
             try:
                 self.commands = [c for c in self.rule.getcommands(self.target, self.makefile)]
             except util.MakeError, e:
-                print e
+                print(e)
                 sys.stdout.flush()
                 cb(error=True)
                 return
@@ -1286,7 +1286,7 @@ class Target(object):
             self.resolvedeps(makefile, targetstack, [], False)
         except util.MakeError, e:
             if printerror:
-                print e
+                print(e)
             self.error = True
             self.notifydone(makefile)
             return
@@ -1398,7 +1398,7 @@ class _CommandWrapper(object):
 
     def _cb(self, res):
         if res != 0 and not self.ignoreErrors:
-            print "%s: command '%s' failed, return code %i" % (self.loc, self.cline, res)
+            print("%s: command '%s' failed, return code %i" % (self.loc, self.cline, res))
             self.usercb(error=True)
         else:
             self.usercb(error=False)
@@ -1597,7 +1597,7 @@ class _RemakeContext(object):
                     'Error remaking required makefiles'))
                 return
             else:
-                print 'Error remaking makefiles (ignored)'
+                print('Error remaking makefiles (ignored)')
 
         if len(self.toremake):
             target, self.required = self.toremake.pop(0)

--- a/pymake/functions.py
+++ b/pymake/functions.py
@@ -1,6 +1,7 @@
 """
 Makefile functions.
 """
+from __future__ import print_function
 
 import parser, util
 import subprocess, os, logging, sys
@@ -786,7 +787,7 @@ class ShellFunction(Function):
             p = subprocess.Popen(cline, executable=executable, env=makefile.env, shell=False,
                                  stdout=subprocess.PIPE, cwd=makefile.workdir)
         except OSError, e:
-            print >>sys.stderr, "Error executing command %s" % cline[0], e
+            print("Error executing command %s" % cline[0], e, file=sys.stderr)
             return
         finally:
             os.environ['PATH'] = oldpath
@@ -830,7 +831,7 @@ class InfoFunction(Function):
 
     def resolve(self, makefile, variables, fd, setting):
         v = self._arguments[0].resolvestr(makefile, variables, setting)
-        print v
+        print(v)
 
 functionmap = {
     'subst': SubstFunction,

--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import logging, re, os
 import data, parser, functions, util
 from cStringIO import StringIO
@@ -207,7 +209,7 @@ class Rule(Statement):
         context.currule = rule
 
     def dump(self, fd, indent):
-        print >>fd, "%sRule %s: %s" % (indent, self.targetexp, self.depexp)
+        print("%sRule %s: %s" % (indent, self.targetexp, self.depexp), file=fd)
 
     def to_source(self):
         sep = ':'
@@ -285,7 +287,7 @@ class StaticPatternRule(Statement):
         context.currule = rule
 
     def dump(self, fd, indent):
-        print >>fd, "%sStaticPatternRule %s: %s: %s" % (indent, self.targetexp, self.patternexp, self.depexp)
+        print("%sStaticPatternRule %s: %s: %s" % (indent, self.targetexp, self.patternexp, self.depexp), file=fd)
 
     def to_source(self):
         sep = ':'
@@ -339,7 +341,7 @@ class Command(Statement):
         context.currule.addcommand(self.exp)
 
     def dump(self, fd, indent):
-        print >>fd, "%sCommand %s" % (indent, self.exp,)
+        print("%sCommand %s" % (indent, self.exp,), file=fd)
 
     def to_source(self):
         # Commands have some interesting quirks when it comes to source
@@ -438,7 +440,7 @@ class SetVariable(Statement):
             v.set(vname, flavor, self.source, value)
 
     def dump(self, fd, indent):
-        print >>fd, "%sSetVariable<%s> %s %s\n%s %r" % (indent, self.valueloc, self.vnameexp, self.token, indent, self.value)
+        print("%sSetVariable<%s> %s %s\n%s %r" % (indent, self.valueloc, self.vnameexp, self.token, indent, self.value), file=fd)
 
     def __eq__(self, other):
         if not isinstance(other, SetVariable):
@@ -651,14 +653,14 @@ class ConditionBlock(Statement):
             i += 1
 
     def dump(self, fd, indent):
-        print >>fd, "%sConditionBlock" % (indent,)
+        print("%sConditionBlock" % (indent,), file=fd)
 
         indent2 = indent + '  '
         for c, statements in self._groups:
-            print >>fd, "%s Condition %s" % (indent, c)
+            print("%s Condition %s" % (indent, c), file=fd)
             statements.dump(fd, indent2)
-            print >>fd, "%s ~Condition" % (indent,)
-        print >>fd, "%s~ConditionBlock" % (indent,)
+            print("%s ~Condition" % (indent,), file=fd)
+        print("%s~ConditionBlock" % (indent,), file=fd)
 
     def to_source(self):
         lines = []
@@ -793,7 +795,7 @@ class Include(Statement):
             makefile.include(f, self.required, loc=self.exp.loc, weak=self.weak)
 
     def dump(self, fd, indent):
-        print >>fd, "%sInclude %s" % (indent, self.exp)
+        print("%sInclude %s" % (indent, self.exp), file=fd)
 
     def to_source(self):
         prefix = ''
@@ -840,7 +842,7 @@ class VPathDirective(Statement):
                     makefile.addvpath(pattern, dirs)
 
     def dump(self, fd, indent):
-        print >>fd, "%sVPath %s" % (indent, self.exp)
+        print("%sVPath %s" % (indent, self.exp), file=fd)
 
     def to_source(self):
         return 'vpath %s' % self.exp.to_source()
@@ -885,7 +887,7 @@ class ExportDirective(Statement):
             makefile.exportedvars[v] = True
 
     def dump(self, fd, indent):
-        print >>fd, "%sExport (single=%s) %s" % (indent, self.single, self.exp)
+        print("%sExport (single=%s) %s" % (indent, self.single, self.exp), file=fd)
 
     def to_source(self):
         return ('export %s' % self.exp.to_source()).rstrip()
@@ -915,7 +917,7 @@ class UnexportDirective(Statement):
             makefile.exportedvars[v] = False
 
     def dump(self, fd, indent):
-        print >>fd, "%sUnexport %s" % (indent, self.exp)
+        print("%sUnexport %s" % (indent, self.exp), file=fd)
 
     def to_source(self):
         return 'unexport %s' % self.exp.to_source()
@@ -947,7 +949,7 @@ class EmptyDirective(Statement):
             raise data.DataError("Line expands to non-empty value", self.exp.loc)
 
     def dump(self, fd, indent):
-        print >>fd, "%sEmptyDirective: %s" % (indent, self.exp)
+        print("%sEmptyDirective: %s" % (indent, self.exp), file=fd)
 
     def to_source(self):
         return self.exp.to_source()

--- a/pymake/process.py
+++ b/pymake/process.py
@@ -2,6 +2,7 @@
 Skipping shell invocations is good, when possible. This wrapper around subprocess does dirty work of
 parsing command lines into argv and making sure that no shell magic is being used.
 """
+from __future__ import print_function
 
 #TODO: ship pyprocessing?
 import multiprocessing
@@ -332,7 +333,7 @@ class PopenJob(Job):
             p = subprocess.Popen(self.argv, executable=self.executable, shell=self.shell, env=self.env, cwd=self.cwd)
             return p.wait()
         except OSError, e:
-            print >>sys.stderr, e
+            print(e, file=sys.stderr)
             return -127
         finally:
             os.environ['PATH'] = oldpath
@@ -383,30 +384,30 @@ class PythonJob(Job):
                 try:
                     __import__(self.module)
                 except Exception as e:
-                    print >>sys.stderr, 'Error importing %s: %s' % (
-                        self.module, e)
+                    print('Error importing %s: %s' % (
+                        self.module, e), file=sys.stderr)
                     return -127
 
             m = sys.modules[self.module]
             if self.method not in m.__dict__:
-                print >>sys.stderr, "No method named '%s' in module %s" % (self.method, self.module)
+                print("No method named '%s' in module %s" % (self.method, self.module), file=sys.stderr)
                 return -127
             rv = m.__dict__[self.method](self.argv)
             if rv != 0 and rv is not None:
-                print >>sys.stderr, (
+                print((
                     "Native command '%s %s' returned value '%s'" %
-                    (self.module, self.method, rv))
+                    (self.module, self.method, rv)), file=sys.stderr)
                 return (rv if isinstance(rv, int) else 1)
 
         except PythonException, e:
-            print >>sys.stderr, e
+            print(e, file=sys.stderr)
             return e.exitcode
         except:
             e = sys.exc_info()[1]
             if isinstance(e, SystemExit) and (e.code == 0 or e.code is None):
                 pass # sys.exit(0) is not a failure
             else:
-                print >>sys.stderr, e
+                print(e, file=sys.stderr)
                 traceback.print_exc()
                 return -127
         finally:
@@ -461,7 +462,7 @@ class ParallelContext(object):
 
     def _docall_generic(self, pool, job, cb, echo, justprint):
         if echo is not None:
-            print echo
+            print(echo)
         processcb = job.get_callback(ParallelContext._condition)
         if justprint:
             processcb(0)

--- a/tests/parsertests.py
+++ b/tests/parsertests.py
@@ -134,7 +134,7 @@ class IterTest(TestBase):
         self.assertEqual(actual, expected)
 
         if ifunc == pymake.parser.itermakefilechars:
-            print "testing %r" % expected
+            print("testing %r" % expected)
             self.assertEqual(pymake.parser.flattenmakesyntax(d, 0), expected)
 
 multitest(IterTest)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -15,6 +15,7 @@ The test file may contain lines at the beginning to alter the default behavior. 
 #T environment: {'VAR': 'VALUE}
 #T grep-for: "text"
 """
+from __future__ import print_function
 
 from subprocess import Popen, PIPE, STDOUT
 from optparse import OptionParser
@@ -78,15 +79,15 @@ def runTest(makefile, make, logfile, options):
     logfd.close()
 
     if stdout.find('TEST-FAIL') != -1:
-        print stdout
+        print(stdout)
         return False, "FAIL (TEST-FAIL printed)"
 
     if options['grepfor'] and stdout.find(options['grepfor']) == -1:
-        print stdout
+        print(stdout)
         return False, "FAIL (%s not in output)" % options['grepfor']
 
     if options['returncode'] == 0 and stdout.find('TEST-PASS') == -1:
-        print stdout
+        print(stdout)
         return False, 'FAIL (No TEST-PASS printed)'
 
     if options['returncode'] != 0:
@@ -94,7 +95,7 @@ def runTest(makefile, make, logfile, options):
 
     return True, 'PASS'
 
-print "%-30s%-28s%-28s" % ("Test:", "gmake:", "pymake:")
+print("%-30s%-28s%-28s" % ("Test:", "gmake:", "pymake:"))
 
 gmakefails = 0
 pymakefails = 0
@@ -153,7 +154,7 @@ for makefile in makefiles:
         elif key == 'skip':
             d['skip'] = True
         else:
-            print >>sys.stderr, "%s: Unexpected #T key: %s" % (makefile, key)
+            print("%s: Unexpected #T key: %s" % (makefile, key), file=sys.stderr)
             sys.exit(1)
 
     mdata.close()
@@ -190,12 +191,12 @@ for makefile in makefiles:
         else:
             pymakemsg = "OK (known fail)"
 
-    print "%-30.30s%-28.28s%-28.28s" % (os.path.basename(makefile),
-                                        gmakemsg, pymakemsg)
+    print("%-30.30s%-28.28s%-28.28s" % (os.path.basename(makefile),
+                                        gmakemsg, pymakemsg))
 
-print
-print "Summary:"
-print "%-30s%-28s%-28s" % ("", "gmake:", "pymake:")
+print()
+print("Summary:")
+print("%-30s%-28s%-28s" % ("", "gmake:", "pymake:"))
 
 if gmakefails == 0:
     gmakemsg = 'PASS'
@@ -207,7 +208,7 @@ if pymakefails == 0:
 else:
     pymakemsg = 'FAIL (%i failures)' % pymakefails
 
-print "%-30.30s%-28.28s%-28.28s" % ('', gmakemsg, pymakemsg)
+print("%-30.30s%-28.28s%-28.28s" % ('', gmakemsg, pymakemsg))
 
 shutil.rmtree(opts.tempdir)
 


### PR DESCRIPTION
I ran everything through 2to3.py and then manually added `from __future__ import print_function` in all modules using "exotic" printing, e.g. redirecting to streams.

```
$ 2to3.py -f print -w
```

I thought I'd do the other 2to3 rewrites separately, as this needed manual intervention.
