### PR TITLE
Py3k-friendly use of StringIO. Remove unused imports.

### DIFF
--- a/pymake/data.py
+++ b/pymake/data.py
@@ -5,7 +5,12 @@ A representation of makefile data structures.
 import logging, re, os, sys
 import parserdata, parser, functions, process, util, implicit
 import globrelative
-from cStringIO import StringIO
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 if sys.version_info[0] < 3:
     str_type = basestring

--- a/pymake/functions.py
+++ b/pymake/functions.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import parser, util
 import subprocess, os, logging, sys
 from globrelative import glob
-from cStringIO import StringIO
+
 
 log = logging.getLogger('pymake.data')
 

--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -2,8 +2,13 @@ from __future__ import print_function
 
 import logging, re, os
 import data, parser, functions, util
-from cStringIO import StringIO
 from pymake.globrelative import hasglob, glob
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 _log = logging.getLogger('pymake.data')
 _tabwidth = 4

--- a/tests/datatests.py
+++ b/tests/datatests.py
@@ -1,7 +1,7 @@
 import pymake.data, pymake.functions, pymake.util
 import unittest
 import re
-from cStringIO import StringIO
+
 
 def multitest(cls):
     for name in cls.testdata.iterkeys():

--- a/tests/parsertests.py
+++ b/tests/parsertests.py
@@ -2,7 +2,6 @@ import pymake.data, pymake.parser, pymake.parserdata, pymake.functions
 import unittest
 import logging
 
-from cStringIO import StringIO
 
 def multitest(cls):
     for name in cls.testdata.iterkeys():


### PR DESCRIPTION
This was done manually. Note that Python 2.7 has an io.StringIO class, but it's strictly Python3-compatible and deals in Unicode strings instead of bytes, so I preferred the classic cStringIO implementation for Python 2.

For the modules where StringIO was imported but not used, I just pruned them.
