### PR TITLE
Explicitly import functools.reduce to play well with py3k.

### DIFF
--- a/pymake/data.py
+++ b/pymake/data.py
@@ -3,6 +3,7 @@ A representation of makefile data structures.
 """
 
 import logging, re, os, sys
+from functools import reduce
 import parserdata, parser, functions, process, util, implicit
 import globrelative
 from cStringIO import StringIO


### PR DESCRIPTION
This one is a little silly, but I wanted to keep it isolated.

As it turns out, that might be a good idea, because I'm suddenly seeing a test going flaky: parallel-simple.mk fails sometimes with this patch applied, and I haven't seen it fail before.

I can't see how this patch would cause any trouble there, and the test looks rather timing-sensitive, so I'm going to blame my antivirus for now.

Just reject it if you feel uncomfortable, and I can reimplement the single use of reduce() with a plain loop or something.
