### PR TITLE
WINFUNCTYPE comes from ctypes, not ctypes.wintypes.

### DIFF
--- a/pymake/win32process.py
+++ b/pymake/win32process.py
@@ -1,5 +1,5 @@
-from ctypes import windll, POINTER, byref, WinError
-from ctypes.wintypes import WINFUNCTYPE, HANDLE, DWORD, BOOL
+from ctypes import windll, POINTER, byref, WinError, WINFUNCTYPE
+from ctypes.wintypes import HANDLE, DWORD, BOOL
 
 INFINITE = -1
 WAIT_FAILED = 0xFFFFFFFF


### PR DESCRIPTION
This is probably just a bug that happens to work on Python 2.
