### PR TITLE
Can't disable buffering on std streams in Python 3.

### DIFF
--- a/make.py
+++ b/make.py
@@ -12,8 +12,13 @@ import pymake.command, pymake.process
 import gc
 
 if __name__ == '__main__':
-  sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
-  sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+  if sys.version_info < (3,0):
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+  else:
+    # Unbuffered text I/O is not allowed in Python 3.
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')
+    sys.stderr = os.fdopen(sys.stderr.fileno(), 'w')
 
   gc.disable()
 


### PR DESCRIPTION
Breakthrough! If I set PYTHONPATH weirdly, I can now start make.py in a directory without a Makefile.

```
$ set PYTHONPATH=%PWD%;%PWD%\pymake
$ which python
C:\Python33\python.EXE
$ python make.py
make.py[0]: Entering directory 'D:\dev\pymake'
No makefile found
$
```

There are still a few `xrange` calls in there, that's my next target. Then I'll probably need some help with untangling dependencies so I can start packaging.
