### PR TITLE
Switch all xrange -> range for Python 3 compatibility.

### DIFF
--- a/pymake/data.py
+++ b/pymake/data.py
@@ -412,7 +412,7 @@ class Expansion(BaseExpansion, list):
         if len(a) != len(b):
             return False
 
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             e1, is_func1 = a[i]
             e2, is_func2 = b[i]
 

--- a/pymake/functions.py
+++ b/pymake/functions.py
@@ -136,7 +136,7 @@ class Function(object):
         if len(self._arguments) != len(other._arguments):
             return False
 
-        for i in xrange(len(self._arguments)):
+        for i in range(len(self._arguments)):
             # According to the GNU make manual Section 8.1, whitespace around
             # arguments is *not* part of the argument's value. So, we do a
             # whitespace-agnostic comparison.
@@ -526,7 +526,7 @@ class JoinFunction(Function):
 
     @staticmethod
     def iterjoin(l1, l2):
-        for i in xrange(0, max(len(l1), len(l2))):
+        for i in range(0, max(len(l1), len(l2))):
             i1 = i < len(l1) and l1[i] or ''
             i2 = i < len(l2) and l2[i] or ''
             yield i1 + i2
@@ -671,7 +671,7 @@ class CallFunction(Function):
 
         v = data.Variables(parent=variables)
         v.set('0', data.Variables.FLAVOR_SIMPLE, data.Variables.SOURCE_AUTOMATIC, vname)
-        for i in xrange(1, len(self._arguments)):
+        for i in range(1, len(self._arguments)):
             param = self._arguments[i].resolvestr(makefile, variables, setting)
             v.set(str(i), data.Variables.FLAVOR_SIMPLE, data.Variables.SOURCE_AUTOMATIC, param)
 

--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -83,7 +83,7 @@ def parsecommandlineargs(args):
     overrides = []
     stmts = StatementList()
     r = []
-    for i in xrange(0, len(args)):
+    for i in range(0, len(args)):
         a = args[i]
 
         vname, t, val = util.strpartition(a, ':=')
@@ -459,7 +459,7 @@ class SetVariable(Statement):
 
     def to_source(self):
         chars = []
-        for i in xrange(0, len(self.value)):
+        for i in range(0, len(self.value)):
             c = self.value[i]
 
             # Literal # is escaped in variable assignment otherwise it would be
@@ -688,7 +688,7 @@ class ConditionBlock(Statement):
         if len(self) != len(other):
             return False
 
-        for i in xrange(0, len(self)):
+        for i in range(0, len(self)):
             our_condition, our_statements = self[i]
             other_condition, other_statements = other[i]
 

--- a/pymake/process.py
+++ b/pymake/process.py
@@ -492,7 +492,7 @@ class ParallelContext(object):
         def _checkdone():
             jobs = []
             for c in ParallelContext._allcontexts:
-                for i in xrange(0, len(c.running)):
+                for i in range(0, len(c.running)):
                     if c.running[i][0].done:
                         jobs.append(c.running[i])
                 for j in jobs:

--- a/tests/datatests.py
+++ b/tests/datatests.py
@@ -63,7 +63,7 @@ class LRUTest(unittest.TestCase):
         c = pymake.util.LRUCache(3, self.spaceFunc, lambda k, v: k % 2)
         self.assertEqual(tuple(c.debugitems()), ())
 
-        for i in xrange(0, len(self.expected)):
+        for i in range(0, len(self.expected)):
             k, e, fc, di = self.expected[i]
 
             v = c.get(k)

--- a/tests/formattingtests.py
+++ b/tests/formattingtests.py
@@ -277,7 +277,7 @@ class MakefileCorupusTest(TestBase):
 
             self.assertEqual(len(statements), len(new_statements))
 
-            for i in xrange(0, len(statements)):
+            for i in range(0, len(statements)):
                 original = statements[i]
                 formatted = new_statements[i]
 

--- a/tests/parsertests.py
+++ b/tests/parsertests.py
@@ -206,7 +206,7 @@ class MakeSyntaxTest(TestBase):
     def compareRecursive(self, actual, expected, path):
         self.assertEqual(len(actual), len(expected),
                          "compareRecursive: %s %r" % (path, actual))
-        for i in xrange(0, len(actual)):
+        for i in range(0, len(actual)):
             ipath = path + [i]
 
             a, isfunc = actual[i]


### PR DESCRIPTION
```
$ 2to3.py -p -fxrange .
```

I haven't measured performance implications of this. Would you like me to do so?

I think some of these cases could switch to use enumerate() for better perf and style on both Python versions, but that sounds like a separate effort.
