### PR TITLE
Replace ``map`` call with a list comprehension to make sure we get a mat...

### DIFF
--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -202,7 +202,8 @@ class Rule(Statement):
 
         deps = list(_expandwildcards(makefile, data.stripdotslashes(self.depexp.resolvesplit(makefile, makefile.variables))))
         if ispattern:
-            rule = data.PatternRule(targets, map(data.Pattern, deps), self.doublecolon, loc=self.targetexp.loc)
+            prerequisites = [data.Pattern(d) for d in deps]
+            rule = data.PatternRule(targets, prerequisites, self.doublecolon, loc=self.targetexp.loc)
             makefile.appendimplicitrule(rule)
         else:
             rule = data.Rule(deps, self.doublecolon, loc=self.targetexp.loc, weakdeps=False)


### PR DESCRIPTION
...erialized list.

I could have wrapped map() in list(), but that would have incurred a double copy on Python 2 (I think, unless there are Python cow optimizations in place for this.)
