### PR TITLE
Replace filter calls with list comprehensions.

### DIFF
--- a/pymake/data.py
+++ b/pymake/data.py
@@ -1762,9 +1762,8 @@ class Makefile(object):
         if value is None:
             self._vpath = []
         else:
-            self._vpath = filter(lambda e: e != '',
-                                 re.split('[%s\s]+' % os.pathsep,
-                                          value.resolvestr(self, self.variables, ['VPATH'])))
+            self._vpath = [e for e in re.split('[%s\s]+' % os.pathsep,
+                                          value.resolvestr(self, self.variables, ['VPATH'])) if e != '']
 
         # Must materialize target values because
         # gettarget() modifies self._targets.

--- a/pymake/globrelative.py
+++ b/pymake/globrelative.py
@@ -62,7 +62,7 @@ def globpattern(dir, pattern):
                   if not leaf.startswith('.')]
 
     leaves = fnmatch.filter(leaves, pattern)
-    leaves = filter(lambda l: os.path.exists(util.normaljoin(dir, l)), leaves)
+    leaves = [l for l in leaves if os.path.exists(util.normaljoin(dir, l))]
 
     leaves.sort()
     return leaves


### PR DESCRIPTION
This makes sure the result is materialized and
can be sorted and iterated more than once.

Performed with:

```
$ 2to3.py -p -ffilter -w .
```

and then compensated for line endings.
