### PR TITLE
Qualify all non-circular imports

### DIFF
--- a/pymake/builtins.py
+++ b/pymake/builtins.py
@@ -2,7 +2,7 @@
 import errno, sys, os, shutil, time
 from getopt import getopt, GetoptError
 
-from process import PythonException
+from pymake.process import PythonException
 
 __all__ = ["mkdir", "rm", "sleep", "touch"]
 

--- a/pymake/command.py
+++ b/pymake/command.py
@@ -11,7 +11,9 @@ except when a submake specifies -j1 when the parent make is building in parallel
 
 import os, subprocess, sys, logging, time, traceback, re
 from optparse import OptionParser
-import data, parserdata, process, util
+
+import data, parserdata, process
+from pymake import util
 
 # TODO: If this ever goes from relocatable package to system-installed, this may need to be
 # a configured-in path.

--- a/pymake/data.py
+++ b/pymake/data.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     from io import StringIO
 
-import parserdata, parser, functions, process, implicit, globrelative
-from pymake import util
+import parserdata, parser, functions, process, globrelative
+from pymake import util, implicit
 
 
 if sys.version_info[0] < 3:

--- a/pymake/data.py
+++ b/pymake/data.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     from io import StringIO
 
-import parserdata, parser, functions, process, globrelative
-from pymake import util, implicit
+import parserdata, parser, functions, process
+from pymake import util, implicit, globrelative
 
 
 if sys.version_info[0] < 3:

--- a/pymake/data.py
+++ b/pymake/data.py
@@ -4,13 +4,14 @@ A representation of makefile data structures.
 
 import logging, re, os, sys
 from functools import reduce
-import parserdata, parser, functions, process, util, implicit
-import globrelative
 
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
+
+import parserdata, parser, functions, process, implicit, globrelative
+from pymake import util
 
 
 if sys.version_info[0] < 3:

--- a/pymake/functions.py
+++ b/pymake/functions.py
@@ -3,10 +3,10 @@ Makefile functions.
 """
 from __future__ import print_function
 
-import parser, util
 import subprocess, os, logging, sys
+import parser
 from globrelative import glob
-
+from pymake import util
 
 log = logging.getLogger('pymake.data')
 

--- a/pymake/functions.py
+++ b/pymake/functions.py
@@ -2,11 +2,10 @@
 Makefile functions.
 """
 from __future__ import print_function
-
 import subprocess, os, logging, sys
+
 import parser
-from globrelative import glob
-from pymake import util
+from pymake import util, globrelative
 
 log = logging.getLogger('pymake.data')
 
@@ -549,7 +548,7 @@ class WildcardFunction(Function):
 
         fd.write(' '.join([x.replace('\\','/')
                            for p in patterns
-                           for x in glob(makefile.workdir, p)]))
+                           for x in globrelative.glob(makefile.workdir, p)]))
 
     @property
     def is_filesystem_dependent(self):

--- a/pymake/globrelative.py
+++ b/pymake/globrelative.py
@@ -7,7 +7,8 @@ Filename globbing like the python glob module with minor differences:
 """
 
 import os, re, fnmatch
-import util
+
+from pymake import util
 
 _globcheck = re.compile('[[*?]')
 

--- a/pymake/parser.py
+++ b/pymake/parser.py
@@ -34,7 +34,10 @@ coming.
 """
 
 import logging, re, os, sys
-import data, functions, util, parserdata
+
+import data, functions, parserdata
+from pymake import util
+
 
 _log = logging.getLogger('pymake.parser')
 

--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -7,8 +7,7 @@ except ImportError:
     from io import StringIO
 
 import data, parser, functions
-from pymake.globrelative import hasglob, glob
-from pymake import util
+from pymake import util, globrelative
 
 _log = logging.getLogger('pymake.data')
 _tabwidth = 4
@@ -65,10 +64,10 @@ class Location(object):
 
 def _expandwildcards(makefile, tlist):
     for t in tlist:
-        if not hasglob(t):
+        if not globrelative.hasglob(t):
             yield t
         else:
-            l = glob(makefile.workdir, t)
+            l = globrelative.glob(makefile.workdir, t)
             for r in l:
                 yield r
 

--- a/pymake/parserdata.py
+++ b/pymake/parserdata.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
-
 import logging, re, os
-import data, parser, functions, util
-from pymake.globrelative import hasglob, glob
 
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 
+import data, parser, functions
+from pymake.globrelative import hasglob, glob
+from pymake import util
 
 _log = logging.getLogger('pymake.data')
 _tabwidth = 4

--- a/pymake/process.py
+++ b/pymake/process.py
@@ -11,7 +11,8 @@ import site
 from collections import deque
 # XXXkhuey Work around http://bugs.python.org/issue1731717
 subprocess._cleanup = lambda: None
-import command, util
+import command
+from pymake import util
 if sys.platform=='win32':
     import win32process
 

--- a/pymake/process.py
+++ b/pymake/process.py
@@ -11,10 +11,11 @@ import site
 from collections import deque
 # XXXkhuey Work around http://bugs.python.org/issue1731717
 subprocess._cleanup = lambda: None
+
 import command
 from pymake import util
 if sys.platform=='win32':
-    import win32process
+    from pymake import win32process
 
 _log = logging.getLogger('pymake.process')
 


### PR DESCRIPTION
These should be entirely non-controversial.

I use `from pymake import xxx` for all modules without circular dependencies.

For the cyclic cluster, I'll need to repartition code, so I'll do these one by one, separately.
