### PR TITLE
Move all exception types to new pymake.errors module.

### DIFF
--- a/pymake/builtins.py
+++ b/pymake/builtins.py
@@ -2,7 +2,7 @@
 import errno, sys, os, shutil, time
 from getopt import getopt, GetoptError
 
-from process import PythonException
+from pymake  import errors
 
 __all__ = ["mkdir", "rm", "sleep", "touch"]
 
@@ -14,7 +14,7 @@ def mkdir(args):
   try:
     opts, args = getopt(args, "p", ["parents"])
   except GetoptError as e:
-    raise PythonException("mkdir: %s" % e, 1)
+    raise errors.PythonError("mkdir: %s" % e, 1)
   parents = False
   for o, a in opts:
     if o in ('-p', '--parents'):
@@ -29,7 +29,7 @@ def mkdir(args):
       if e.errno == errno.EEXIST and parents:
         pass
       else:
-        raise PythonException("mkdir: %s" % e, 1)
+        raise errors.PythonError("mkdir: %s" % e, 1)
 
 def rm(args):
   """
@@ -39,7 +39,7 @@ def rm(args):
   try:
     opts, args = getopt(args, "rRf", ["force", "recursive"])
   except GetoptError as e:
-    raise PythonException("rm: %s" % e, 1)
+    raise errors.PythonError("rm: %s" % e, 1)
   force = False
   recursive = False
   for o, a in opts:
@@ -50,7 +50,7 @@ def rm(args):
   for f in args:
     if os.path.isdir(f):
       if not recursive:
-        raise PythonException("rm: cannot remove '%s': Is a directory" % f, 1)
+        raise errors.PythonError("rm: cannot remove '%s': Is a directory" % f, 1)
       else:
         shutil.rmtree(f, force)
     elif os.path.exists(f):
@@ -58,9 +58,9 @@ def rm(args):
         os.unlink(f)
       except:
         if not force:
-          raise PythonException("rm: failed to remove '%s': %s" % (f, sys.exc_info()[0]), 1)
+          raise errors.PythonError("rm: failed to remove '%s': %s" % (f, sys.exc_info()[0]), 1)
     elif not force:
-      raise PythonException("rm: cannot remove '%s': No such file or directory" % f, 1)
+      raise errors.PythonError("rm: cannot remove '%s': No such file or directory" % f, 1)
 
 def sleep(args):
     """
@@ -79,7 +79,7 @@ def sleep(args):
             f = float(a)
             total += f * multiplier
         except ValueError:
-            raise PythonException("sleep: invalid time interval '%s'" % a, 1)
+            raise errors.PythonError("sleep: invalid time interval '%s'" % a, 1)
     time.sleep(total)
 
 def touch(args):
@@ -89,7 +89,7 @@ def touch(args):
     try:
         opts, args = getopt(args, "t:")
     except GetoptError as e:
-        raise PythonException("touch: %s" % e, 1)
+        raise errors.PythonError("touch: %s" % e, 1)
     opts = dict(opts)
     times = None
     if '-t' in opts:
@@ -97,7 +97,7 @@ def touch(args):
         from time import mktime, localtime
         m = re.match('^(?P<Y>(?:\d\d)?\d\d)?(?P<M>\d\d)(?P<D>\d\d)(?P<h>\d\d)(?P<m>\d\d)(?:\.(?P<s>\d\d))?$', opts['-t'])
         if not m:
-            raise PythonException("touch: invalid date format '%s'" % opts['-t'], 1)
+            raise errors.PythonError("touch: invalid date format '%s'" % opts['-t'], 1)
         def normalized_field(m, f):
             if f == 'Y':
                 if m.group(f) is None:

--- a/pymake/command.py
+++ b/pymake/command.py
@@ -12,6 +12,7 @@ except when a submake specifies -j1 when the parent make is building in parallel
 import os, subprocess, sys, logging, time, traceback, re
 from optparse import OptionParser
 import data, parserdata, process, util
+from pymake import errors
 
 # TODO: If this ever goes from relocatable package to system-installed, this may need to be
 # a configured-in path.
@@ -50,7 +51,7 @@ def parsemakeflags(env):
         if c == '\\':
             i += 1
             if i == len(makeflags):
-                raise data.DataError("MAKEFLAGS has trailing backslash")
+                raise errors.DataError("MAKEFLAGS has trailing backslash")
             c = makeflags[i]
             
         curopt += c
@@ -124,7 +125,7 @@ class _MakeContext(object):
                     self.makefile.include(f)
                 self.makefile.finishparsing()
                 self.makefile.remakemakefiles(self.remakecb)
-            except util.MakeError as e:
+            except errors.MakeError as e:
                 print(e)
                 self.context.defer(self.cb, 2)
 
@@ -269,7 +270,7 @@ def main(args, env, cwd, cb):
         ostmts, targets, overrides = parserdata.parsecommandlineargs(arguments)
 
         _MakeContext(makeflags, makelevel, workdir, context, env, targets, options, ostmts, overrides, cb)
-    except (util.MakeError) as e:
+    except errors.MakeError as e:
         print(e)
         if options.printdir:
             print("make.py[%i]: Leaving directory '%s'" % (makelevel, workdir))

--- a/pymake/errors.py
+++ b/pymake/errors.py
@@ -1,0 +1,42 @@
+
+
+class MakeError(Exception):
+    def __init__(self, message, loc=None):
+        self.msg = message
+        self.loc = loc
+
+    def __str__(self):
+        locstr = ''
+        if self.loc is not None:
+            locstr = "%s:" % (self.loc,)
+
+        return "%s%s" % (locstr, self.msg)
+
+
+class SyntaxError(MakeError):
+    pass
+
+
+class DataError(MakeError):
+    pass
+
+
+class ResolutionError(DataError):
+    """
+    Raised when dependency resolution fails, either due to recursion or to missing
+    prerequisites.This is separately catchable so that implicit rule search can try things
+    without having to commit.
+    """
+    pass
+
+
+class PythonError(Exception):
+    def __init__(self, message, exitcode):
+        Exception.__init__(self)
+        self.message = message
+        self.exitcode = exitcode
+
+    def __str__(self):
+        return self.message
+
+

--- a/pymake/process.py
+++ b/pymake/process.py
@@ -12,6 +12,7 @@ from collections import deque
 # XXXkhuey Work around http://bugs.python.org/issue1731717
 subprocess._cleanup = lambda: None
 import command, util
+from pymake import errors
 if sys.platform=='win32':
     import win32process
 
@@ -338,16 +339,6 @@ class PopenJob(Job):
         finally:
             os.environ['PATH'] = oldpath
 
-class PythonException(Exception):
-    def __init__(self, message, exitcode):
-        Exception.__init__(self)
-        self.message = message
-        self.exitcode = exitcode
-
-    def __str__(self):
-        return self.message
-
-
 class PythonJob(Job):
     """
     A job that calls a Python method.
@@ -399,7 +390,7 @@ class PythonJob(Job):
                     (self.module, self.method, rv)), file=sys.stderr)
                 return (rv if isinstance(rv, int) else 1)
 
-        except PythonException as e:
+        except errors.PythonError as e:
             print(e, file=sys.stderr)
             return e.exitcode
         except:

--- a/pymake/util.py
+++ b/pymake/util.py
@@ -1,17 +1,5 @@
 import os
 
-class MakeError(Exception):
-    def __init__(self, message, loc=None):
-        self.msg = message
-        self.loc = loc
-
-    def __str__(self):
-        locstr = ''
-        if self.loc is not None:
-            locstr = "%s:" % (self.loc,)
-
-        return "%s%s" % (locstr, self.msg)
-
 def normaljoin(path, suffix):
     """
     Combine the given path with the suffix, and normalize if necessary to shrink the path to avoid hitting path length limits


### PR DESCRIPTION
In an effort to reduce dependency cycles, per my suggestion in e-mail, here's a first step to put all exception types in a common errors module.
